### PR TITLE
Add redirect rule for biorxiv

### DIFF
--- a/src/redirectify.js
+++ b/src/redirectify.js
@@ -21,7 +21,8 @@ RULES = [
   ["*://*.jmlr.org/*", /papers\/volume(.*)\/[^\/]*.pdf$/, '/papers/v$1.html'],
   ["*://delivery.acm.org/*", /.*delivery.acm.org\/[0-9.]*\/[0-9.]*\/([0-9]*)\/.*/,
     'https://dl.acm.org/citation.cfm?id=$1', '.acm.org'],
-  ["*://papers.nips.cc/*", /\.pdf$/, '']
+  ["*://papers.nips.cc/*", /\.pdf$/, ''],
+  ["*://*biorxiv.org/*", /(.*)\/biorxiv\/(.*?)(.full.pdf)?$/, '$1/$2']
 ];
 
 var browser = browser || chrome;


### PR DESCRIPTION
This PR adds support for [biorxiv](https://www.biorxiv.org) links that suffer from the same issue.

Tested on some links:
```
> rule = ["*://*biorxiv.org/*", /(.*)\/biorxiv\/(.*?)(.full.pdf)?$/, '$1/$2']
[ '*://*biorxiv.org/*',
  /(.*)\/biorxiv\/(.*?)(.full.pdf)?$/,
  '$1/$2' ]
> link = https://www.biorxiv.org/content/biorxiv/early/2017/09/18/113480.full.pdf
> link = 'https://www.biorxiv.org/content/biorxiv/early/2017/09/18/113480.full.pdf'
'https://www.biorxiv.org/content/biorxiv/early/2017/09/18/113480.full.pdf'
> link.replace(rule[1], rule[2])
'https://www.biorxiv.org/content/early/2017/09/18/113480'
> link = https://www.biorxiv.org/content/biorxiv/early/2018/03/03/275545.full.pdf
> link = 'https://www.biorxiv.org/content/biorxiv/early/2018/03/03/275545.full.pdf'
'https://www.biorxiv.org/content/biorxiv/early/2018/03/03/275545.full.pdf'
> link.replace(rule[1], rule[2])
'https://www.biorxiv.org/content/early/2018/03/03/275545'
```

If there are any sanity checks to run let me know!