### PR TITLE
Add CDS and indico redirects for CERN hosted pdfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# ignore the generated extension files
+*.xpi
+*.zip
+
+# ignore temporary chrome thing
+*tmp_*/

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ available in the PDF, such as the version history. I've given up trying to ask
 people not to deep-link to PDFs, and have instead written a browser extension to
 do what I want.
 
-Install links: [Firefox](https://addons.mozilla.org/en-US/firefox/addon/redirectify/) and [Chrome](https://chrome.google.com/webstore/detail/redirectify/mhjmbfadcbhilcfdhkkepffbnjaghfie)
+Install link: [Firefox](https://addons.mozilla.org/en-US/firefox/addon/redirectify-cern/)
 
 This Firefox/Chrome extension redirects links to PDFs on arXiv, JMLR, NIPS,
 OpenReview and PMLR to an HTML index page, unless you clicked on the link from
@@ -27,17 +27,6 @@ I've given the extension a fairly generic name. The redirect rules are stored in
 a list at the top of the code, and can easily be added to. However, making this
 list updatable within the extension is unlikely to happen soon, partly because
 of time, partly because allowing any URL to be redirected opens up security issues.
-
-
-## Download
-
-If you just want to use the extension as it is, get it from one of the official addon
-sites:
-
-* [Redirectify for Firefox](https://addons.mozilla.org/en-US/firefox/addon/redirectify/)
-
-* [Redirectify for Chrome](https://chrome.google.com/webstore/detail/redirectify/mhjmbfadcbhilcfdhkkepffbnjaghfie)
-
 
 ## Alternatives
 

--- a/package.sh
+++ b/package.sh
@@ -2,11 +2,11 @@
 
 set -e
 
-EXTENSION=redirectify
+EXTENSION=redirectify-cern
 SRC=src
 
 # Set working directory to location of this script
-cd $(dirname $(readlink -m "$0"))
+cd $(dirname $(greadlink -m "$0"))
 
 VERSION=$(grep '"version":' src/manifest.json | sed 's/.*"\([0-9.]*\)".*/\1/')
 OUT="$EXTENSION"-"$VERSION"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,6 +20,8 @@
     "*://papers.nips.cc/*.pdf",
     "*://pdfs.semanticscholar.org/*",
     "*://*.biorxiv.org/content*",
+    "*://indico.cern.ch/event/*/contributions/*/attachments/*.pdf",
+    "*://cds.cern.ch/record/*/files/*.pdf",
     "webRequest",
     "webRequestBlocking"
   ],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
   "name": "Redirectify-CERN",
   "version": "0.1.0",
 
-  "description": "Redirects requests for PDFs of papers at some popular sites to their corresponding HTML index pages.",
+  "description": "Redirects requests for PDFs of papers at some popular sites to their corresponding HTML index pages. This is a CERN-specific fork.",
 
   "homepage_url": "https://github.com/dguest/redirectify",
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,12 +1,12 @@
 {
 
   "manifest_version": 2,
-  "name": "Redirectify",
-  "version": "0.2.4",
+  "name": "Redirectify-CERN",
+  "version": "0.1.0",
 
   "description": "Redirects requests for PDFs of papers at some popular sites to their corresponding HTML index pages.",
 
-  "homepage_url": "https://github.com/imurray/redirectify",
+  "homepage_url": "https://github.com/dguest/redirectify",
 
   "permissions": [
     "*://*.arxiv.org/pdf/*",

--- a/src/redirectify.js
+++ b/src/redirectify.js
@@ -28,7 +28,9 @@ RULES = [
   ["*://papers.nips.cc/*.pdf", /\.pdf$/, ''],
   ["*://pdfs.semanticscholar.org/*", /.*lar.org\/([0-9a-f]{4})\/([0-9a-f]{36}).pdf/, 'https://www.semanticscholar.org/paper/$1$2',
     '.semanticscholar.org'],
-  ["*://*.biorxiv.org/content*", /((.*\/)biorxiv\/|)(.*)(\.full\.pdf)(\?.*)?$/, '$2$3']
+  ["*://*.biorxiv.org/content*", /((.*\/)biorxiv\/|)(.*)(\.full\.pdf)(\?.*)?$/, '$2$3'],
+  ["*://indico.cern.ch/event/*/contributions/*/attachments/*.pdf", /(.*)\/contributions\/(.*)\/attachments\/.*/, '$1/contributions/$2'],
+  ["*://cds.cern.ch/record/*/files/*.pdf", /(.*)\/files\/.*/, '$1/files']
 ];
 
 var browser = browser || chrome;


### PR DESCRIPTION
This adds a few extra URLs which CERN experiments use to host documents.
 - [Indico][1] is a conference management tool hosted at CERN. It is used by all the LHC experiments, plus a number of other scientific collaborations.
 - [CDS][1] is the CERN document server. Several LHC experiments have very restrictive rules on what is submitted to journals (and the arXiv), meaning a large fraction of LHC papers can only be found here.

[1]: https://indico.cern.ch/
[2]: https://cds.cern.ch/