### PR TITLE
Add CDS and indico redirects

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,6 +20,8 @@
     "*://papers.nips.cc/*.pdf",
     "*://pdfs.semanticscholar.org/*",
     "*://*.biorxiv.org/content*",
+    "*://indico.cern.ch/event/*/contributions/*/attachments/*.pdf",
+    "*://cds.cern.ch/record/*/files/*.pdf",
     "webRequest",
     "webRequestBlocking"
   ],

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -20,7 +20,7 @@
     "*://papers.nips.cc/*.pdf",
     "*://pdfs.semanticscholar.org/*",
     "*://*.biorxiv.org/content*",
-    "*://indico.cern.ch/event/*/contributions/*/attachments/*.pdf",
+    "*://indico.cern.ch/event/*/attachments/*.pdf",
     "*://cds.cern.ch/record/*/files/*.pdf",
     "webRequest",
     "webRequestBlocking"

--- a/src/redirectify.js
+++ b/src/redirectify.js
@@ -28,7 +28,9 @@ RULES = [
   ["*://papers.nips.cc/*.pdf", /\.pdf$/, ''],
   ["*://pdfs.semanticscholar.org/*", /.*lar.org\/([0-9a-f]{4})\/([0-9a-f]{36}).pdf/, 'https://www.semanticscholar.org/paper/$1$2',
     '.semanticscholar.org'],
-  ["*://*.biorxiv.org/content*", /((.*\/)biorxiv\/|)(.*)(\.full\.pdf)(\?.*)?$/, '$2$3']
+  ["*://*.biorxiv.org/content*", /((.*\/)biorxiv\/|)(.*)(\.full\.pdf)(\?.*)?$/, '$2$3'],
+  ["*://indico.cern.ch/event/*/contributions/*/attachments/*.pdf", /(.*)\/contributions\/(.*)\/attachments\/.*/, '$1/contributions/$2'],
+  ["*://cds.cern.ch/record/*/files/*.pdf", /(.*)\/files\/.*/, '$1/files']
 ];
 
 var browser = browser || chrome;

--- a/src/redirectify.js
+++ b/src/redirectify.js
@@ -29,7 +29,7 @@ RULES = [
   ["*://pdfs.semanticscholar.org/*", /.*lar.org\/([0-9a-f]{4})\/([0-9a-f]{36}).pdf/, 'https://www.semanticscholar.org/paper/$1$2',
     '.semanticscholar.org'],
   ["*://*.biorxiv.org/content*", /((.*\/)biorxiv\/|)(.*)(\.full\.pdf)(\?.*)?$/, '$2$3'],
-  ["*://indico.cern.ch/event/*/contributions/*/attachments/*.pdf", /(.*)\/contributions\/(.*)\/attachments\/.*/, '$1/contributions/$2'],
+  ["*://indico.cern.ch/event/*/attachments/*.pdf", /(.*)\/([a-z]*)\/(.*)\/attachments\/.*/, '$1/$2/$3'],
   ["*://cds.cern.ch/record/*/files/*.pdf", /(.*)\/files\/.*/, '$1/files']
 ];
 


### PR DESCRIPTION
This adds a few extra URLs which CERN experiments use to host documents.
 - [Indico][1] is a conference management tool hosted at CERN. It is used by all the LHC experiments, plus a number of other scientific collaborations.
 - [CDS][1] is the CERN document server. Several LHC experiments have very restrictive rules on what is submitted to journals (and the arXiv), meaning a large fraction of LHC papers can only be found here.

[1]: https://indico.cern.ch/
[2]: https://cds.cern.ch/
